### PR TITLE
LEI Improvement

### DIFF
--- a/src/LEI.py
+++ b/src/LEI.py
@@ -10,7 +10,6 @@ from shapely.geometry import shape, GeometryCollection
 from shapely.wkt import loads
 from shapely.errors import TopologicalError
 from rasterstats import zonal_stats
-from tqdm import tqdm
 
 custom_dict = {
     0 : 'new',
@@ -44,7 +43,7 @@ def calculate_LEI(inputGHSL, old_list = [4,5,6], new_list=[3], buffer_dist=300):
     newR = (np.isin(inR, new_list)).astype('int')
     oldR = (np.isin(inR, old_list)).astype('int')
     allVals = []
-    for geom, value in tqdm(rasterio.features.shapes(newR.astype('uint8'), transform=inRaster.transform)):
+    for geom, value in rasterio.features.shapes(newR.astype('uint8'), transform=inRaster.transform):
         if value == 1:
             # Convert the geom to a shape and buffer by 300 metres
             curShape = shape(geom)

--- a/src/LEI.py
+++ b/src/LEI.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from shapely.geometry import shape, GeometryCollection
 from shapely.wkt import loads
+from shapely.errors import TopologicalError
 
 def calculate_LEI(inputGHSL, old_list = [4,5,6], new_list=[3], buffer_dist=300):
     ''' Calculate LEI using vector objects in rasterio
@@ -42,7 +43,11 @@ def calculate_LEI(inputGHSL, old_list = [4,5,6], new_list=[3], buffer_dist=300):
             curShape = shape(geom)
             bufferArea = curShape.buffer(buffer_dist)
             #Clip out the original shape to leave just the donut
-            donutArea = bufferArea.difference(curShape)
+            try:
+                donutArea = bufferArea.difference(curShape)
+            except TopologicalError:
+                curShape = curShape.buffer(0)
+                donutArea = bufferArea.difference(curShape)
             # Rasterize donut shape
             shapes = [(donutArea, 1)]
             burned = rasterio.features.rasterize(shapes=shapes, fill=0, 

--- a/src/LEI.py
+++ b/src/LEI.py
@@ -9,6 +9,13 @@ import numpy as np
 from shapely.geometry import shape, GeometryCollection
 from shapely.wkt import loads
 from shapely.errors import TopologicalError
+from rasterstats import zonal_stats
+from tqdm import tqdm
+
+custom_dict = {
+    0 : 'new',
+    1 : 'old'
+}
 
 def calculate_LEI(inputGHSL, old_list = [4,5,6], new_list=[3], buffer_dist=300):
     ''' Calculate LEI using vector objects in rasterio
@@ -37,7 +44,7 @@ def calculate_LEI(inputGHSL, old_list = [4,5,6], new_list=[3], buffer_dist=300):
     newR = (np.isin(inR, new_list)).astype('int')
     oldR = (np.isin(inR, old_list)).astype('int')
     allVals = []
-    for geom, value in rasterio.features.shapes(newR.astype('uint8'), transform=inRaster.transform):
+    for geom, value in tqdm(rasterio.features.shapes(newR.astype('uint8'), transform=inRaster.transform)):
         if value == 1:
             # Convert the geom to a shape and buffer by 300 metres
             curShape = shape(geom)
@@ -48,15 +55,10 @@ def calculate_LEI(inputGHSL, old_list = [4,5,6], new_list=[3], buffer_dist=300):
             except TopologicalError:
                 curShape = curShape.buffer(0)
                 donutArea = bufferArea.difference(curShape)
-            # Rasterize donut shape
-            shapes = [(donutArea, 1)]
-            burned = rasterio.features.rasterize(shapes=shapes, fill=0, 
-                             out_shape=(oldR.shape[1], oldR.shape[2]), 
-                             transform=inRaster.transform)
-            # Multiply the new raster by the old urban data to get the total
-            #     amount of old area in the buffer around the new urban area
-            oldArea = (oldR[0,:,:] * burned).sum()
-            totalArea = burned.sum()
+            zs = zonal_stats(donutArea, oldR[0,:,:], affine=inRaster.transform, categorical=True, category_map=custom_dict, nodata=-9999)
+            oldArea = zs[0]['old'] if 'old' in zs[0].keys() else 0
+            newArea = zs[0]['new'] if 'new' in zs[0].keys() else 0
+            totalArea = newArea + oldArea
             allVals.append([curShape, oldArea, totalArea])
     return(allVals)
     


### PR DESCRIPTION
I'm suggesting this implementation for the LEI function. It does the same thing, but it's much  faster. Instead of writing a big raster and then multiplying the built-up raster to get old area and new area, it gets the same numbers using a zonal stats count function.

This also fixes a topological error when the donut had a hole (self ring intersect).